### PR TITLE
Support for a listener to be notified of upload progress

### DIFF
--- a/src/main/java/com/cloudapp/api/CloudApp.java
+++ b/src/main/java/com/cloudapp/api/CloudApp.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.cloudapp.api.model.CloudAppAccount;
 import com.cloudapp.api.model.CloudAppAccountStats;
 import com.cloudapp.api.model.CloudAppItem;
+import com.cloudapp.api.model.CloudAppProgressListener;
 
 public interface CloudApp {
 
@@ -58,7 +59,7 @@ public interface CloudApp {
       throws CloudAppException;
 
   /**
-   * Dispatch an email containing a link to reset the accountÕs password.
+   * Dispatch an email containing a link to reset the accountï¿½s password.
    * 
    * @see http://developer.getcloudapp.com/forgot-password
    * @param email
@@ -94,7 +95,7 @@ public interface CloudApp {
 
   /**
    * Add or change the domain used for all links. Optionally, a URL may be provided to
-   * redirect visitors to the custom domainÕs root. <b>Pro users only</b>
+   * redirect visitors to the custom domainï¿½s root. <b>Pro users only</b>
    * 
    * @see http://developer.getcloudapp.com/set-custom-domain
    * @param domain
@@ -208,6 +209,18 @@ public interface CloudApp {
    * @return
    */
   public CloudAppItem upload(File file) throws CloudAppException;
+
+  /**
+   *
+   * @see http://developer.getcloudapp.com/upload-file
+   * @param file
+   *          The file you wish to upload.
+   * @param listener
+   *          To receive progress updates during upload
+   * @throws CloudAppException
+   * @return
+   */
+  public CloudAppItem upload(File file, CloudAppProgressListener listener) throws CloudAppException;
 
   /**
    * Deletes an item

--- a/src/main/java/com/cloudapp/api/model/CloudAppProgressListener.java
+++ b/src/main/java/com/cloudapp/api/model/CloudAppProgressListener.java
@@ -1,0 +1,12 @@
+package com.cloudapp.api.model;
+
+/**
+ * Listener to receive notification as data's written to the output stream during upload.
+ */
+public interface CloudAppProgressListener {
+    void transferred(long written, long length);
+    
+    public static CloudAppProgressListener NO_OP = new CloudAppProgressListener() {
+        public void transferred(long written, long length) {}
+    };
+}

--- a/src/main/java/com/cloudapp/impl/CloudAppImpl.java
+++ b/src/main/java/com/cloudapp/impl/CloudAppImpl.java
@@ -3,6 +3,7 @@ package com.cloudapp.impl;
 import java.io.File;
 import java.util.List;
 
+import com.cloudapp.api.model.CloudAppProgressListener;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.impl.DefaultConnectionReuseStrategy;
@@ -184,6 +185,16 @@ public class CloudAppImpl implements CloudApp {
    */
   public CloudAppItem upload(File file) throws CloudAppException {
     return items.upload(file);
+  }
+
+  /**
+   *
+   * {@inheritDoc}
+   *
+   * @see com.cloudapp.api.CloudAppItems#upload(java.io.File, com.cloudapp.api.model.CloudAppProgressListener)
+   */
+  public CloudAppItem upload(File file, CloudAppProgressListener listener) throws CloudAppException {
+    return items.upload(file, listener);
   }
 
   /**

--- a/src/main/java/com/cloudapp/impl/CloudAppInputStream.java
+++ b/src/main/java/com/cloudapp/impl/CloudAppInputStream.java
@@ -23,29 +23,64 @@
 
 package com.cloudapp.impl;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.InputStream;
+import java.io.*;
 
+import com.cloudapp.api.model.CloudAppProgressListener;
 import org.apache.http.entity.mime.content.InputStreamBody;
 
 public class CloudAppInputStream extends InputStreamBody {
 
-  private long length;
+    private final long length;
+    private final CloudAppProgressListener listener;
 
-  public CloudAppInputStream(InputStream in, String filename, long length) {
-    super(in, filename);
-    this.length = length;
-  }
+    public CloudAppInputStream(InputStream in, String filename, long length, CloudAppProgressListener listener) {
+        super(in, filename);
+        this.length = length;
+        this.listener = (listener == null) ? CloudAppProgressListener.NO_OP : listener;
+    }
 
-  protected CloudAppInputStream(File file) throws FileNotFoundException {
-    this(new FileInputStream(file), file.getName(), file.length());
-  }
+    protected CloudAppInputStream(File file, CloudAppProgressListener listener) throws FileNotFoundException {
+        this(new FileInputStream(file), file.getName(), file.length(), listener);
+    }
 
-  @Override
-  public long getContentLength() {
-    return length;
-  }
+    @Override
+    public void writeTo(OutputStream out) throws IOException {
+        super.writeTo( new ListeningOutputStream(out) );
+    }
+
+    @Override
+    public long getContentLength() {
+        return length;
+    }
+    
+    private class ListeningOutputStream extends FilterOutputStream {
+        
+        private long bytesWritten;
+
+        public ListeningOutputStream(OutputStream out) {
+            super(out);
+            bytesWritten = 0L;
+        }
+        
+        @Override
+        public void write(int b) throws IOException {
+            out.write(b);
+            listener.transferred(++bytesWritten, length);
+        }
+        
+        @Override
+        public void write(byte[] b) throws IOException {
+            out.write(b);
+            bytesWritten += b.length;
+            listener.transferred(bytesWritten, length);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            out.write(b, off, len);
+            bytesWritten += (len - off);
+            listener.transferred(bytesWritten, length);
+        }
+    }
 
 }

--- a/src/main/java/com/cloudapp/impl/CloudAppItemsImpl.java
+++ b/src/main/java/com/cloudapp/impl/CloudAppItemsImpl.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.cloudapp.api.CloudAppException;
+import com.cloudapp.api.model.CloudAppProgressListener;
 import com.cloudapp.api.model.CloudAppItem;
 import com.cloudapp.impl.model.CloudAppItemImpl;
 
@@ -155,61 +156,67 @@ public class CloudAppItemsImpl extends CloudAppBase {
     }
   }
 
-  /**
-   * 
-   * {@inheritDoc}
-   * 
-   * @see com.cloudapp.api.CloudAppItems#upload(java.io.File)
-   */
-  public CloudAppItem upload(File file) throws CloudAppException {
-    try {
-      // Do a GET request so we have the S3 endpoint
-      HttpGet req = new HttpGet(NEW_ITEM_URL);
-      req.addHeader("Accept", "application/json");
-      HttpResponse response = client.execute(req);
-      int status = response.getStatusLine().getStatusCode();
-      String responseBody = EntityUtils.toString(response.getEntity());
-      if (status != 200)
-        throw new CloudAppException(status, responseBody, null);
-
-      JSONObject json = new JSONObject(responseBody);
-      if (!json.has("params")) {
-        // Something went wrong, maybe we crossed the treshold?
-        if (json.getInt("uploads_remaining") == 0) {
-          throw new CloudAppException(200, "Uploads remaining is 0", null);
-        }
-        throw new CloudAppException(500, "Missing params object from the CloudApp API.",
-            null);
-      }
-
-      return uploadToAmazon(json, file);
-
-    } catch (ClientProtocolException e) {
-      LOGGER.error("Something went wrong trying to contact the CloudApp API.", e);
-      throw new CloudAppException(500,
-          "Something went wrong trying to contact the CloudApp API", e);
-    } catch (IOException e) {
-      LOGGER.error("Something went wrong trying to contact the CloudApp API.", e);
-      throw new CloudAppException(500,
-          "Something went wrong trying to contact the CloudApp API.", e);
-    } catch (JSONException e) {
-      LOGGER.error("Something went wrong trying to handle JSON.", e);
-      throw new CloudAppException(500, "Something went wrong trying to handle JSON.", e);
+    /**
+     *
+     * {@inheritDoc}
+     *
+     * @see com.cloudapp.api.CloudAppItems#upload(java.io.File)
+     */
+    public CloudAppItem upload(File file) throws CloudAppException {
+        return upload( file, CloudAppProgressListener.NO_OP );
     }
-  }
+
+    public CloudAppItem upload(File file, CloudAppProgressListener listener) throws CloudAppException {
+        try {
+            // Do a GET request so we have the S3 endpoint
+            HttpGet req = new HttpGet(NEW_ITEM_URL);
+            req.addHeader("Accept", "application/json");
+            HttpResponse response = client.execute(req);
+            int status = response.getStatusLine().getStatusCode();
+            String responseBody = EntityUtils.toString(response.getEntity());
+            if (status != 200)
+                throw new CloudAppException(status, responseBody, null);
+
+            JSONObject json = new JSONObject(responseBody);
+            if (!json.has("params")) {
+                // Something went wrong, maybe we crossed the treshold?
+                if (json.getInt("uploads_remaining") == 0) {
+                    throw new CloudAppException(200, "Uploads remaining is 0", null);
+                }
+                throw new CloudAppException(500, "Missing params object from the CloudApp API.",
+                        null);
+            }
+
+            return uploadToAmazon(json, file, listener);
+
+        } catch (ClientProtocolException e) {
+            LOGGER.error("Something went wrong trying to contact the CloudApp API.", e);
+            throw new CloudAppException(500,
+                    "Something went wrong trying to contact the CloudApp API", e);
+        } catch (IOException e) {
+            LOGGER.error("Something went wrong trying to contact the CloudApp API.", e);
+            throw new CloudAppException(500,
+                    "Something went wrong trying to contact the CloudApp API.", e);
+        } catch (JSONException e) {
+            LOGGER.error("Something went wrong trying to handle JSON.", e);
+            throw new CloudAppException(500, "Something went wrong trying to handle JSON.", e);
+        }
+    }
 
   /**
    * Uploads a file to S3
    * 
+   *
    * @param json
    * @param file
+   * @param listener
    * @return
    * @throws JSONException
    * @throws CloudAppException
    * @throws ParseException
    * @throws IOException
    */
-  private CloudAppItem uploadToAmazon(JSONObject json, File file) throws JSONException,
+  private CloudAppItem uploadToAmazon(JSONObject json, File file, CloudAppProgressListener listener) throws JSONException,
       CloudAppException, ParseException, IOException {
     JSONObject params = json.getJSONObject("params");
     MultipartEntity entity = new MultipartEntity(HttpMultipartMode.BROWSER_COMPATIBLE);
@@ -223,7 +230,7 @@ public class CloudAppItemsImpl extends CloudAppBase {
 
     // Add the actual file.
     // We have to use the 'file' parameter for the S3 storage.
-    InputStreamBody stream = new CloudAppInputStream(file);
+    InputStreamBody stream = new CloudAppInputStream(file, listener);
     entity.addPart("file", stream);
 
     HttpPost uploadRequest = new HttpPost(json.getString("url"));

--- a/src/main/java/com/cloudapp/impl/CloudAppItemsImpl.java
+++ b/src/main/java/com/cloudapp/impl/CloudAppItemsImpl.java
@@ -156,60 +156,58 @@ public class CloudAppItemsImpl extends CloudAppBase {
     }
   }
 
-    /**
-     *
-     * {@inheritDoc}
-     *
-     * @see com.cloudapp.api.CloudAppItems#upload(java.io.File)
-     */
-    public CloudAppItem upload(File file) throws CloudAppException {
-        return upload( file, CloudAppProgressListener.NO_OP );
-    }
+  /**
+   * 
+   * {@inheritDoc}
+   * 
+   * @see com.cloudapp.api.CloudAppItems#upload(java.io.File)
+   */
+  public CloudAppItem upload(File file) throws CloudAppException {
+    return upload( file, CloudAppProgressListener.NO_OP );
+  }
 
-    public CloudAppItem upload(File file, CloudAppProgressListener listener) throws CloudAppException {
-        try {
-            // Do a GET request so we have the S3 endpoint
-            HttpGet req = new HttpGet(NEW_ITEM_URL);
-            req.addHeader("Accept", "application/json");
-            HttpResponse response = client.execute(req);
-            int status = response.getStatusLine().getStatusCode();
-            String responseBody = EntityUtils.toString(response.getEntity());
-            if (status != 200)
-                throw new CloudAppException(status, responseBody, null);
+  public CloudAppItem upload(File file, CloudAppProgressListener listener) throws CloudAppException {
+    try {
+      // Do a GET request so we have the S3 endpoint
+      HttpGet req = new HttpGet(NEW_ITEM_URL);
+      req.addHeader("Accept", "application/json");
+      HttpResponse response = client.execute(req);
+      int status = response.getStatusLine().getStatusCode();
+      String responseBody = EntityUtils.toString(response.getEntity());
+      if (status != 200)
+        throw new CloudAppException(status, responseBody, null);
 
-            JSONObject json = new JSONObject(responseBody);
-            if (!json.has("params")) {
-                // Something went wrong, maybe we crossed the treshold?
-                if (json.getInt("uploads_remaining") == 0) {
-                    throw new CloudAppException(200, "Uploads remaining is 0", null);
-                }
-                throw new CloudAppException(500, "Missing params object from the CloudApp API.",
-                        null);
-            }
-
-            return uploadToAmazon(json, file, listener);
-
-        } catch (ClientProtocolException e) {
-            LOGGER.error("Something went wrong trying to contact the CloudApp API.", e);
-            throw new CloudAppException(500,
-                    "Something went wrong trying to contact the CloudApp API", e);
-        } catch (IOException e) {
-            LOGGER.error("Something went wrong trying to contact the CloudApp API.", e);
-            throw new CloudAppException(500,
-                    "Something went wrong trying to contact the CloudApp API.", e);
-        } catch (JSONException e) {
-            LOGGER.error("Something went wrong trying to handle JSON.", e);
-            throw new CloudAppException(500, "Something went wrong trying to handle JSON.", e);
+      JSONObject json = new JSONObject(responseBody);
+      if (!json.has("params")) {
+        // Something went wrong, maybe we crossed the treshold?
+        if (json.getInt("uploads_remaining") == 0) {
+          throw new CloudAppException(200, "Uploads remaining is 0", null);
         }
+        throw new CloudAppException(500, "Missing params object from the CloudApp API.",
+            null);
+      }
+
+      return uploadToAmazon(json, file, listener);
+
+    } catch (ClientProtocolException e) {
+      LOGGER.error("Something went wrong trying to contact the CloudApp API.", e);
+      throw new CloudAppException(500,
+          "Something went wrong trying to contact the CloudApp API", e);
+    } catch (IOException e) {
+      LOGGER.error("Something went wrong trying to contact the CloudApp API.", e);
+      throw new CloudAppException(500,
+          "Something went wrong trying to contact the CloudApp API.", e);
+    } catch (JSONException e) {
+      LOGGER.error("Something went wrong trying to handle JSON.", e);
+      throw new CloudAppException(500, "Something went wrong trying to handle JSON.", e);
     }
+  }
 
   /**
    * Uploads a file to S3
    * 
-   *
    * @param json
    * @param file
-   * @param listener
    * @return
    * @throws JSONException
    * @throws CloudAppException

--- a/src/test/java/com/cloudapp/impl/CloudAppItemsImplTest.java
+++ b/src/test/java/com/cloudapp/impl/CloudAppItemsImplTest.java
@@ -5,7 +5,9 @@ import static org.junit.Assert.assertEquals;
 import java.io.File;
 import java.net.URL;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
+import com.cloudapp.api.model.CloudAppProgressListener;
 import org.json.JSONException;
 import org.junit.Assert;
 import org.junit.Before;
@@ -16,12 +18,13 @@ import com.cloudapp.api.model.CloudAppItem;
 
 public class CloudAppItemsImplTest extends BaseTestCase {
 
-  private File file;
+    private static final String TEST_FILE_NAME = "test_file.txt";
+    private File file;
 
   @Before
   public void setUp() {
     super.setUp();
-    URL fileurl = getClass().getResource("/test_file.txt");
+    URL fileurl = getClass().getResource( "/" + TEST_FILE_NAME );
     file = new File(fileurl.getPath());
   }
 
@@ -50,7 +53,7 @@ public class CloudAppItemsImplTest extends BaseTestCase {
   public void testUpload() throws CloudAppException, JSONException {
     CloudAppItem o = api.upload(file);
     Assert.assertNotNull(o);
-    assertEquals("test_file.txt", o.getName());
+    assertEquals(TEST_FILE_NAME, o.getName());
     Assert.assertNotNull(o.getCreatedAt());
   }
   
@@ -59,4 +62,16 @@ public class CloudAppItemsImplTest extends BaseTestCase {
     List<CloudAppItem> l = api.getItems(1, 5, null, false, null);
     Assert.assertNotNull(l);
   }
+
+    @Test
+    public void testUploadListener() throws CloudAppException, JSONException {
+        final AtomicLong calledCount = new AtomicLong();
+        CloudAppItem o = api.upload(file, new CloudAppProgressListener() {
+            public void transferred(long written, long length) {
+                calledCount.incrementAndGet();
+            }
+        });
+        assertEquals( TEST_FILE_NAME, o.getName() );
+        assertEquals( 1, calledCount.get() );
+    }
 }


### PR DESCRIPTION
Adding support to optionally use a listener to track upload progress. Callbacks to the listener will be at the frequency of the underlying InputStreamBody implementation (which appears to be 4KB increments).

Simple example test case added at CloudAppItemsImplTest.
