### PR TITLE
Typo fix in CloudApp.java

### DIFF
--- a/src/main/java/com/cloudapp/api/CloudApp.java
+++ b/src/main/java/com/cloudapp/api/CloudApp.java
@@ -59,7 +59,7 @@ public interface CloudApp {
       throws CloudAppException;
 
   /**
-   * Dispatch an email containing a link to reset the account�s password.
+   * Dispatch an email containing a link to reset the account's password.
    * 
    * @see http://developer.getcloudapp.com/forgot-password
    * @param email
@@ -95,7 +95,7 @@ public interface CloudApp {
 
   /**
    * Add or change the domain used for all links. Optionally, a URL may be provided to
-   * redirect visitors to the custom domain�s root. <b>Pro users only</b>
+   * redirect visitors to the custom domain's root. <b>Pro users only</b>
    * 
    * @see http://developer.getcloudapp.com/set-custom-domain
    * @param domain


### PR DESCRIPTION
Corrected a typo in the javadoc comments.
